### PR TITLE
Support for PHPUnit 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.2
   - 7.3
   - 7.4
   - 8.0

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "phpunit/phpunit": "^8.0",
+        "php": ">=7.3",
+        "phpunit/phpunit": "^9.0",
         "ext-gd": "*"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         beStrictAboutTestsThatDoNotTestAnything="false">
-    <testsuites>
-        <testsuite name="Test Suite for meyfa/phpunit-assert-gd">
-            <directory suffix="Test.php">tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/autoload.php"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <testsuites>
+    <testsuite name="Test Suite for meyfa/phpunit-assert-gd">
+      <directory suffix="Test.php">tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
Fixes https://github.com/meyfa/phpunit-assert-gd/issues/4.

As per [my comment](https://github.com/meyfa/phpunit-assert-gd/issues/4#issuecomment-773022300), this PR assumes that this would be released as a new major version.

I've tested this against the [October CMS Rain library](https://github.com/octobercms/library) which we use this library for testing, and it didn't seem to require any changes to work with PHPUnit 9, beyond changing the constraints.