### PR TITLE
chore: Require PHP v8.1 or later in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.1",
         "phpunit/phpunit": "^10.1",
         "ext-gd": "*"
     },


### PR DESCRIPTION
This is in accordance with PHPUnit's own requirement.